### PR TITLE
Bugfix for invalid sql query when using labels

### DIFF
--- a/bigquerydb/client.go
+++ b/bigquerydb/client.go
@@ -239,13 +239,13 @@ func (c *BigqueryClient) buildCommand(q *prompb.Query) (string, error) {
 		// Labels
 		switch m.Type {
 		case prompb.LabelMatcher_EQ:
-			matchers = append(matchers, fmt.Sprintf("JSON_EXTRACT(tags, '$.%q') = '%s')", m.Name, escapeSingleQuotes(m.Value)))
+			matchers = append(matchers, fmt.Sprintf(`JSON_EXTRACT(tags, '$.%s') = '"%s"'`, m.Name, m.Value))
 		case prompb.LabelMatcher_NEQ:
-			matchers = append(matchers, fmt.Sprintf("JSON_EXTRACT(tags, '$.%q') = '%s')", m.Name, escapeSingleQuotes(m.Value)))
+			matchers = append(matchers, fmt.Sprintf(`JSON_EXTRACT(tags, '$.%s') = '"%s"'`, m.Name, m.Value))
 		case prompb.LabelMatcher_RE:
-			matchers = append(matchers, fmt.Sprintf("REGEXP_CONTAINS(JSON_EXTRACT(tags, '$.%q'), r'%s')", m.Name, escapeSlashes(m.Value)))
+			matchers = append(matchers, fmt.Sprintf(`REGEXP_CONTAINS(JSON_EXTRACT(tags, '$.%s'), r'"%s"')`, m.Name, m.Value))
 		case prompb.LabelMatcher_NRE:
-			matchers = append(matchers, fmt.Sprintf("not REGEXP_CONTAINS(JSON_EXTRACT(tags, '$.%q'), r'%s')", m.Name, escapeSlashes(m.Value)))
+			matchers = append(matchers, fmt.Sprintf(`not REGEXP_CONTAINS(JSON_EXTRACT(tags, '$.%s'), r'"%s"')`, m.Name, m.Value))
 		default:
 			return "", errors.Errorf("unknown match type %v", m.Type)
 		}
@@ -254,7 +254,7 @@ func (c *BigqueryClient) buildCommand(q *prompb.Query) (string, error) {
 	matchers = append(matchers, fmt.Sprintf("timestamp <= TIMESTAMP_MILLIS(%v)", q.EndTimestampMs))
 
 	query := fmt.Sprintf("SELECT metricname, tags, timestamp, value FROM %s.%s WHERE %v", c.datasetID, c.tableID, strings.Join(matchers, " AND "))
-	level.Debug(c.logger).Log("msg", "BiQuery read", "sql query", query)
+	level.Debug(c.logger).Log("msg", "BigQuery read", "sql query", query)
 
 	return query, nil
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -26,7 +26,7 @@ var (
 	Branch    string
 	BuildDate string
 	GitSHA1   string
-	Version   = "v0.2.0"
+	Version   = "v0.2.1"
 )
 
 // Print writes application version details to standard output.


### PR DESCRIPTION
## Description

Reads were failing due to invalid SQL queries when using labels, like described below.

```
global:
  external_labels:
    monitor: "my-awesome-prometheus"
```

## Type of change

* Bug fix (non-breaking change which fixes an issue)