### PR TITLE
Add read/write error counts to Bigquery

### DIFF
--- a/main.go
+++ b/main.go
@@ -288,7 +288,6 @@ func serve(logger log.Logger, addr string, writers []writer, readers []reader) e
 			level.Warn(logger).Log("msg", "Error writing response", "storage", reader.Name(), "err", err)
 			readErrors.Inc()
 		}
-		readErrors.Inc()
 	})
 
 	return http.ListenAndServe(addr, nil)

--- a/main.go
+++ b/main.go
@@ -83,13 +83,13 @@ var (
 	)
 	writeErrors = prometheus.NewCounter(
 		prometheus.CounterOpts{
-			Name: "storage_bigquery_write_error_total",
+			Name: "storage_bigquery_write_errors_total",
 			Help: "Total number of write errors to BigQuery.",
 		},
 	)
 	readErrors = prometheus.NewCounter(
 		prometheus.CounterOpts{
-			Name: "storage_bigquery_read_error_total",
+			Name: "storage_bigquery_read_errors_total",
 			Help: "Total number of read errors from BigQuery.",
 		},
 	)


### PR DESCRIPTION
This change exposes metrics for the number of read errors from and write errors to Bigquery for prometheus to scrape.

Partially fixes Issue #9