### PR TITLE
Write speed metric for Client to BigQuery

### DIFF
--- a/bigquerydb/client.go
+++ b/bigquerydb/client.go
@@ -180,6 +180,7 @@ func (c *BigqueryClient) Write(timeseries []*prompb.TimeSeries) error {
 		}
 	}
 	duration := time.Since(begin).Seconds()
+	level.Debug(c.logger).Log("msg", "Duration: ", duration)
 	c.writeDuration.Observe(duration)
 	defer cancel()
 	return nil
@@ -205,12 +206,14 @@ func (c BigqueryClient) Name() string {
 func (c *BigqueryClient) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.ignoredSamples.Desc()
 	ch <- c.recordsFetched.Desc()
+	ch <- c.writeDuration.Desc()
 }
 
 // Collect implements prometheus.Collector.
 func (c *BigqueryClient) Collect(ch chan<- prometheus.Metric) {
 	ch <- c.ignoredSamples
 	ch <- c.recordsFetched
+	ch <- c.writeDuration
 }
 
 // Read queries the database and returns the results to Prometheus

--- a/bigquerydb/client.go
+++ b/bigquerydb/client.go
@@ -37,14 +37,14 @@ import (
 
 // BigqueryClient allows sending batches of Prometheus samples to Bigquery.
 type BigqueryClient struct {
-	logger         log.Logger
-	client         bigquery.Client
-	datasetID      string
-	tableID        string
-	timeout        time.Duration
-	ignoredSamples prometheus.Counter
-	recordsFetched prometheus.Counter
-	writeDuration  prometheus.Histogram
+	logger             log.Logger
+	client             bigquery.Client
+	datasetID          string
+	tableID            string
+	timeout            time.Duration
+	ignoredSamples     prometheus.Counter
+	recordsFetched     prometheus.Counter
+	batchWriteDuration prometheus.Histogram
 }
 
 // NewClient creates a new Client.
@@ -179,7 +179,7 @@ func (c *BigqueryClient) Write(timeseries []*prompb.TimeSeries) error {
 			return err
 		}
 		duration := time.Since(begin).Seconds()
-		c.writeDuration.Observe(duration)
+		c.batchWriteDuration.Observe(duration)
 	}
 	defer cancel()
 	return nil
@@ -205,14 +205,14 @@ func (c BigqueryClient) Name() string {
 func (c *BigqueryClient) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.ignoredSamples.Desc()
 	ch <- c.recordsFetched.Desc()
-	ch <- c.writeDuration.Desc()
+	ch <- c.batchWriteDuration.Desc()
 }
 
 // Collect implements prometheus.Collector.
 func (c *BigqueryClient) Collect(ch chan<- prometheus.Metric) {
 	ch <- c.ignoredSamples
 	ch <- c.recordsFetched
-	ch <- c.writeDuration
+	ch <- c.batchWriteDuration
 }
 
 // Read queries the database and returns the results to Prometheus

--- a/bigquerydb/client.go
+++ b/bigquerydb/client.go
@@ -97,7 +97,7 @@ func NewClient(logger log.Logger, googleAPIjsonkeypath, googleAPIdatasetID, goog
 		batchWriteDuration: prometheus.NewHistogram(
 			prometheus.HistogramOpts{
 				Name:    "storage_bigquery_batch_write_duration_seconds",
-				Help:    "The duration it takes to write a batch sample to BigQuery.",
+				Help:    "The duration it takes to write a batch of samples to BigQuery.",
 				Buckets: prometheus.DefBuckets,
 			},
 		),

--- a/bigquerydb/client.go
+++ b/bigquerydb/client.go
@@ -94,10 +94,10 @@ func NewClient(logger log.Logger, googleAPIjsonkeypath, googleAPIdatasetID, goog
 				Help: "Total number of records fetched",
 			},
 		),
-		writeDuration: prometheus.NewHistogram(
+		batchWriteDuration: prometheus.NewHistogram(
 			prometheus.HistogramOpts{
-				Name:    "storage_bigquery_write_batch_duration_seconds",
-				Help:    "The write duration from BigQuery to prometheus?",
+				Name:    "storage_bigquery_batch_write_duration_seconds",
+				Help:    "The duration it takes to write a batch sample to be written to BigQuery.",
 				Buckets: prometheus.DefBuckets,
 			},
 		),

--- a/bigquerydb/client.go
+++ b/bigquerydb/client.go
@@ -97,7 +97,7 @@ func NewClient(logger log.Logger, googleAPIjsonkeypath, googleAPIdatasetID, goog
 		batchWriteDuration: prometheus.NewHistogram(
 			prometheus.HistogramOpts{
 				Name:    "storage_bigquery_batch_write_duration_seconds",
-				Help:    "The duration it takes to write a batch sample to be written to BigQuery.",
+				Help:    "The duration it takes to write a batch sample to BigQuery.",
 				Buckets: prometheus.DefBuckets,
 			},
 		),


### PR DESCRIPTION
This change adds a prometheus metric to the client that sends batch samples to BigQuery. This metric is a histogram that uses the default buckets defined by prometheus. [0.005, 0.01, 0.025,0.05,0.1,0.25,0.5,1.0,2.5,5.0.10.0, +inf] 

- New feature (non-breaking change which adds functionality)
