### PR TITLE
SQL query metrics

### DIFF
--- a/bigquerydb/client.go
+++ b/bigquerydb/client.go
@@ -104,7 +104,7 @@ func NewClient(logger log.Logger, googleAPIjsonkeypath, googleAPIdatasetID, goog
 		sqlQueryDuration: prometheus.NewHistogram(
 			prometheus.HistogramOpts{
 				Name:    "storage_bigquery_sql_query_duration_seconds",
-				Help:    "Duration of the sql writes to BigQuery.",
+				Help:    "Duration of the sql reads from BigQuery.",
 				Buckets: prometheus.DefBuckets,
 			},
 		),

--- a/bigquerydb/client.go
+++ b/bigquerydb/client.go
@@ -104,7 +104,7 @@ func NewClient(logger log.Logger, googleAPIjsonkeypath, googleAPIdatasetID, goog
 		sqlQueryDuration: prometheus.NewHistogram(
 			prometheus.HistogramOpts{
 				Name:    "storage_bigquery_sql_query_duration_seconds",
-				Help:    "Duration of the sql writes to Big Query.",
+				Help:    "Duration of the sql writes to BigQuery.",
 				Buckets: prometheus.DefBuckets,
 			},
 		),


### PR DESCRIPTION
This change adds a prometheus metric to the client tracking total SQL reads and the duration of the reads in a histogram. This metric is a histogram that uses the default buckets defined by prometheus. [0.005, 0.01, 0.025,0.05,0.1,0.25,0.5,1.0,2.5,5.0.10.0, +inf]

Partially fixes Issue #9

New feature (non-breaking change which adds functionality)