### PR TITLE
Return metric values if labels are null

### DIFF
--- a/bigquerydb/client.go
+++ b/bigquerydb/client.go
@@ -296,13 +296,13 @@ func (c *BigqueryClient) buildCommand(q *prompb.Query) (string, error) {
 		// Labels
 		switch m.Type {
 		case prompb.LabelMatcher_EQ:
-			matchers = append(matchers, fmt.Sprintf(`JSON_EXTRACT(tags, '$.%s') = '"%s"'`, m.Name, m.Value))
+			matchers = append(matchers, fmt.Sprintf(`IFNULL(JSON_EXTRACT(tags, '$.%s'), '""') = '"%s"'`, m.Name, m.Value))
 		case prompb.LabelMatcher_NEQ:
-			matchers = append(matchers, fmt.Sprintf(`JSON_EXTRACT(tags, '$.%s') = '"%s"'`, m.Name, m.Value))
+			matchers = append(matchers, fmt.Sprintf(`IFNULL(JSON_EXTRACT(tags, '$.%s'), '""') = '"%s"'`, m.Name, m.Value))
 		case prompb.LabelMatcher_RE:
-			matchers = append(matchers, fmt.Sprintf(`REGEXP_CONTAINS(JSON_EXTRACT(tags, '$.%s'), r'"%s"')`, m.Name, m.Value))
+			matchers = append(matchers, fmt.Sprintf(`REGEXP_CONTAINS(IFNULL(JSON_EXTRACT(tags, '$.%s'), '""'), r'"%s"')`, m.Name, m.Value))
 		case prompb.LabelMatcher_NRE:
-			matchers = append(matchers, fmt.Sprintf(`not REGEXP_CONTAINS(JSON_EXTRACT(tags, '$.%s'), r'"%s"')`, m.Name, m.Value))
+			matchers = append(matchers, fmt.Sprintf(`not REGEXP_CONTAINS(IFNULL(JSON_EXTRACT(tags, '$.%s'), '""'), r'"%s"')`, m.Name, m.Value))
 		default:
 			return "", errors.Errorf("unknown match type %v", m.Type)
 		}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -26,7 +26,7 @@ var (
 	Branch    string
 	BuildDate string
 	GitSHA1   string
-	Version   = "v0.4.0"
+	Version   = "v0.4.1"
 )
 
 // Print writes application version details to standard output.


### PR DESCRIPTION

# Pull Request Template

## Description

When labels are undefined, having a filter such as `my_label~='.*'` returns data from local storage, but not from BigQuery.
This pull request replaces the `null` value for the label with an empty string, which results in the regex working as expected.

## Type of change
* Bug fix (non-breaking change which fixes an issue)
