### PR TITLE
Correctly report number of rows and duration of reads

### DIFF
--- a/bigquerydb/client.go
+++ b/bigquerydb/client.go
@@ -247,9 +247,6 @@ func (c *BigqueryClient) Read(req *prompb.ReadRequest) (*prompb.ReadResponse, er
 		c.sqlQueryCount.Inc()
 		begin := time.Now()
 		iter, err := query.Read(ctx)
-		duration := time.Since(begin).Seconds()
-		c.sqlQueryDuration.Observe(duration)
-		level.Debug(c.logger).Log("msg", "BigQuery SQL query", "rows received", iter.TotalRows)
 		defer cancel()
 
 		if err != nil {
@@ -259,6 +256,9 @@ func (c *BigqueryClient) Read(req *prompb.ReadRequest) (*prompb.ReadResponse, er
 		if err = mergeResult(tsMap, iter); err != nil {
 			return nil, err
 		}
+		duration := time.Since(begin).Seconds()
+		c.sqlQueryDuration.Observe(duration)
+		level.Debug(c.logger).Log("msg", "BigQuery SQL query", "rows", iter.TotalRows, "duration", duration)
 	}
 
 	resp := prompb.ReadResponse{

--- a/main.go
+++ b/main.go
@@ -319,6 +319,7 @@ func serve(logger log.Logger, addr string, writers []writer, readers []reader) e
 		}
 		duration := time.Since(begin).Seconds()
 		readProcessingDuration.WithLabelValues(writers[0].Name()).Observe(duration)
+		level.Debug(logger).Log("msg", "/read", "duration", duration)
 	})
 
 	return http.ListenAndServe(addr, nil)


### PR DESCRIPTION
## Description

The number of returned rows is now correctly reported during read operations. The calculation of the read duratin has also been corrected.

## Type of change

* Bug fix (non-breaking change which fixes an issue)
