### PR TITLE
chore: bump to Go 1.17.8

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -12,7 +12,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.17.6, 1.16.11]
+        go-version: [1.17.8, 1.16.11]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -57,7 +57,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.6
+          go-version: 1.17.8
       - name: Prepare
         id: prep
         run: |


### PR DESCRIPTION
Dockerfile will be updated in #73.