### PR TITLE
core: bump to Go 1.18.1

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -27,7 +27,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3.1.0
       with:
-        version: v1.43.0
+        version: v1.45.2
         skip-go-installation: true
         skip-pkg-cache: true
         skip-build-cache: true

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -44,7 +44,7 @@ jobs:
       uses: goreleaser/goreleaser-action@v2
       with:
         install-only: true
-        version: v1.0.0
+        version: v1.7.0
     - name: Test GoReleaser
       run: make test-release
   deploy:
@@ -83,7 +83,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v2
         with:
           install-only: true
-          version: v1.0.0
+          version: v1.7.0
       - name: Run GoReleaser
         run: make release
         env:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -12,7 +12,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.17.8, 1.16.11]
+        go-version: [1.18.1, 1.17.9]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -57,7 +57,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17.8
+          go-version: 1.18.1
       - name: Prepare
         id: prep
         run: |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/KohlsTechnology/prometheus_bigquery_remote_storage_adapter
 
-go 1.17
+go 1.18
 
 require (
 	cloud.google.com/go/bigquery v1.31.0

--- a/go.sum
+++ b/go.sum
@@ -91,7 +91,6 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=


### PR DESCRIPTION
- Bump to Go 1.18.1
- Bump to golangci-lint 1.45.2
- Bump go goreleaser 1.7.0