### PR TITLE
Fix NEQ label matchers

### DIFF
--- a/bigquerydb/client.go
+++ b/bigquerydb/client.go
@@ -295,7 +295,7 @@ func (c *BigqueryClient) buildCommand(q *prompb.Query) (string, error) {
 		case prompb.LabelMatcher_EQ:
 			matchers = append(matchers, fmt.Sprintf(`IFNULL(JSON_EXTRACT(tags, '$.%s'), '""') = '"%s"'`, m.Name, m.Value))
 		case prompb.LabelMatcher_NEQ:
-			matchers = append(matchers, fmt.Sprintf(`IFNULL(JSON_EXTRACT(tags, '$.%s'), '""') = '"%s"'`, m.Name, m.Value))
+			matchers = append(matchers, fmt.Sprintf(`IFNULL(JSON_EXTRACT(tags, '$.%s'), '""') != '"%s"'`, m.Name, m.Value))
 		case prompb.LabelMatcher_RE:
 			matchers = append(matchers, fmt.Sprintf(`REGEXP_CONTAINS(IFNULL(JSON_EXTRACT(tags, '$.%s'), '""'), r'"%s"')`, m.Name, m.Value))
 		case prompb.LabelMatcher_NRE:


### PR DESCRIPTION
# Pull Request Template

## Description

Non-name NEQ label matchers queries were erroneously being built with `=` instead of `!=`.

## Type of change

* Bug fix (non-breaking change which fixes an issue)

## Environment

* Runtime version Go 1.18.1
