### PR TITLE
Enable Running Unit Tests in CI

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -31,15 +31,14 @@ jobs:
         skip-go-installation: true
         skip-pkg-cache: true
         skip-build-cache: true
-    # TODO: unit tests require cloud credentials
-    #- name: Test
-    #  run: make test-unit
-    #- name: Upload coverage to Codecov
-    #  uses: codecov/codecov-action@v1
-    #  with:
-    #    fail_ci_if_error: true
-    #    files: ./coverage.txt
-    #    verbose: true
+    - name: Test
+      run: make test-unit
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3.1.0
+      with:
+        fail_ci_if_error: true
+        files: ./coverage.txt
+        verbose: true
     - name: Install GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/bigquerydb/client_test.go
+++ b/bigquerydb/client_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
 Copyright 2020 Kohl's Department Stores, Inc.
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,7 +28,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// example call: go test -v -args -googleAPIjsonkeypath=../../project-credential.json -googleAPIdatasetID=prometheus_test -googleAPItableID=test_stream ./...
+// example call: go test -tags=e2e -v -args -googleAPIjsonkeypath=../../project-credential.json -googleAPIdatasetID=prometheus_test -googleAPItableID=test_stream ./...
 
 var logger = log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout))
 

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2022 Kohl's Department Stores, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+)
+
+// TestGetVersion calls version.Get checking for a valid version string.
+func TestGetVersion(t *testing.T) {
+	want := fmt.Sprintf("prometheus_bigquery_remote_storage_adapter, version v0.4.6 (branch: , revision: ), build date: , go version: %v", runtime.Version())
+	msg := Get()
+	if want != msg {
+		t.Fatalf("wanted %q, but got %q", want, msg)
+	}
+}


### PR DESCRIPTION
## Description

* Wrote first unit test for pkg/version
* Tests that require GCP BigQuery have the build tag e2e
* Note e2e tests are not run as part of CI yet

Is related to #43.