### PR TITLE
Enable Running Local e2e Tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,4 @@ prometheus_bigquery_remote_storage_adapter
 .idea
 *.swp
 .vscode
-test.sh
 

--- a/README.md
+++ b/README.md
@@ -165,41 +165,27 @@ $ GITHUB_TOKEN=xxx make clean release
 
 ## Testing
 
-### Credentials via Google API json key file
-
-Use the `--googleAPIjsonkeypath` argument to indicate the keyfile path (note: the GCP Project ID will be automatically extracted from the specified file).
-
-
+### Running Unit Tests
 ```
-go test -v -cover ./... -args \
-  --googleAPIjsonkeypath=XXX \
-  --googleAPIdatasetID=XXX \
-  --googleAPItableID=XXX \
+make test-unit
 ```
 
-### Credentials via `GOOGLE_APPLICATION_CREDENTIALS`
-
-Use the `--googleProjectID` argument to indicate the GCP Project ID and let _Google Application Default Credentials_ ([ADC](https://cloud.google.com/docs/authentication/production#automatically)) identify the service account from the `GOOGLE_APPLICATION_CREDENTIALS` environment variable.
-
-```
-GOOGLE_APPLICATION_CREDENTIALS=../../private.key.json \
-go test -v -cover ./... -args \
-  --googleProjectID=XXX \
-  --googleAPIdatasetID=XXX \
-  --googleAPItableID=XXX \
-```
-
-### Credentials via default service account
-
-Identify the service account via Google Application Default Credentials ([ADC](https://cloud.google.com/docs/authentication/production#automatically)).
-
-Use the `--googleProjectID` argument to indicate GCP Project ID and let ADC identify the default service account. This will only work if you're running on Google's infrastructure (GCP VMs, GKE, etc.).
+### Running E2E Tests
+Running the e2e tests requires a real GCP BigQuery instance to connect to.
 
 ```
-go test -v -cover ./... -args \
-  --googleProjectID=XXX \
-  --googleAPIdatasetID=XXX \
-  --googleAPItableID=XXX \
+make gcloud-auth
+make bq-setup
+make test-e2e
+make bq-cleanup
+make clean
+```
+
+To override the GCP project used for testing set the `GCP_PROJECT_ID` variable.
+```
+GCP_PROJECT_ID=my-awesome-project make bq-setup
+GCP_PROJECT_ID=my-awesome-project make test-e2e
+GCP_PROJECT_ID=my-awesome-project make bq-cleanup
 ```
 
 ## Prometheus Metrics Offered

--- a/bigquerydb/client_test.go
+++ b/bigquerydb/client_test.go
@@ -16,7 +16,6 @@ limitations under the License.
 package bigquerydb
 
 import (
-	"flag"
 	"fmt"
 	"math"
 	"os"
@@ -28,20 +27,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// example call: go test -tags=e2e -v -args -googleAPIjsonkeypath=../../project-credential.json -googleAPIdatasetID=prometheus_test -googleAPItableID=test_stream ./...
-
 var logger = log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout))
 
-var googleAPIjsonkeypath string
-var googleAPIdatasetID string
-var googleAPItableID string
-var googleProjectID string
-
-func init() {
-	flag.StringVar(&googleAPIjsonkeypath, "googleAPIjsonkeypath", "foo", "Path to json keyfile for GCP service account. JSON keyfile also contains project_id")
-	flag.StringVar(&googleAPIdatasetID, "googleAPIdatasetID", "bar", "Dataset name as shown in GCP.")
-	flag.StringVar(&googleAPItableID, "googleAPItableID", "baz", "Table name as shown in GCP.")
-}
+var googleAPIdatasetID = os.Getenv("BQ_DATASET_NAME")
+var googleAPItableID = os.Getenv("BQ_TABLE_NAME")
+var googleProjectID = os.Getenv("GCP_PROJECT_ID")
 
 func TestNaN(t *testing.T) {
 
@@ -98,7 +88,7 @@ func TestNaN(t *testing.T) {
 
 	thirtysecondtimeout, _ := time.ParseDuration("30s")
 
-	bqclient := NewClient(logger, googleAPIjsonkeypath, googleProjectID, googleAPIdatasetID, googleAPItableID, thirtysecondtimeout)
+	bqclient := NewClient(logger, "", googleProjectID, googleAPIdatasetID, googleAPItableID, thirtysecondtimeout)
 
 	if err := bqclient.Write(timeseriesGood); err != nil {
 		fmt.Println("Error sending samples: ", err)
@@ -175,7 +165,7 @@ func TestWriteRead(t *testing.T) {
 
 	thirtysecondtimeout, _ := time.ParseDuration("30s")
 
-	bqclient := NewClient(logger, googleAPIjsonkeypath, googleProjectID, googleAPIdatasetID, googleAPItableID, thirtysecondtimeout)
+	bqclient := NewClient(logger, "", googleProjectID, googleAPIdatasetID, googleAPItableID, thirtysecondtimeout)
 
 	if err := bqclient.Write(timeseries); err != nil {
 		fmt.Println("Error sending samples: ", err)

--- a/bq-schema.json
+++ b/bq-schema.json
@@ -1,0 +1,26 @@
+[
+    {
+      "description": "Name of the Prometheus metric",
+      "mode": "NULLABLE",
+      "name": "metricname",
+      "type": "STRING"
+    },
+    {
+      "description": "Prometheus metrics labels stored as JSON string",
+      "mode": "NULLABLE",
+      "name": "tags",
+      "type": "STRING"
+    },
+    {
+      "description": "Prometheus metrics timestamp",
+      "mode": "NULLABLE",
+      "name": "timestamp",
+      "type": "TIMESTAMP"
+    },
+    {
+        "description": "Value of the Prometheus metric",
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "FLOAT"
+      }
+  ]

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 /*
 Copyright 2022 Kohl's Department Stores, Inc.
 


### PR DESCRIPTION
## Description

Enable Running Local e2e Tests

Running the e2e tests are now 100% automated including all BigQuery setup and clean up steps. All tests can be run using make targets similar to all other local development tasks.

Also, unit and e2e tests can be run separately.

At this time the e2e tests are not run automatically as part of CI via GitHub Actions. This enhancement will be done in the future.
