### PR TITLE
Bump CI to Go 1.19.1 and 1.18.6

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -12,7 +12,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.19.0, 1.18.5]
+        go-version: [1.19.1, 1.18.6]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -56,7 +56,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.0
+          go-version: 1.19.1
       - name: Prepare
         id: prep
         run: |


### PR DESCRIPTION
Dockerfile will be updated in #140.