### PR TITLE
BugFix: Ensure CHANGELOG include all commits for release

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -83,6 +83,8 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Install Go
         uses: actions/setup-go@v3
         with:


### PR DESCRIPTION
## Description

Per the goreleaser docs, you must set fetch depthness when checking out the code for GoReleaser to work properly.

The warning in the docs to configure GitHub Actions states:

> Fetch depthness
> Notice the fetch-depth: 0 option on the Checkout workflow
> step. It is required for GoReleaser to work properly.
> Without that, GoReleaser might fail or behave incorrectly.

Ref: https://goreleaser.com/ci/actions/

In addition, there is a common errors page that notes if you are only seeing one commit, it is likely because GoReleaser was run against a shallow clone.

Ref https://goreleaser.com/errors/no-history/

Fixes #186 

## Type of change

* Bug fix (non-breaking change which fixes an issue)