### PR TITLE
chore(ci): update deprecated `set-output` command

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -95,7 +95,7 @@ jobs:
           DOCKER_IMAGE=quay.io/kohlstechnology/prometheus_bigquery_remote_storage_adapter
           VERSION=${GITHUB_REF#refs/tags/}
           TAGS="${DOCKER_IMAGE}:${VERSION},${DOCKER_IMAGE}:latest"
-          echo ::set-output name=tags::${TAGS}
+          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Login to quay.io


### PR DESCRIPTION
## Description

Update deprecated `set-output` usage in deploy job

Fixes #194 

## Type of change

* Bug fix (non-breaking change which fixes an issue)

## Additional Links

- Documentation for `set-output` deprecation - https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
