### PR TITLE
chore(ci): checkout code before setting up go in test Action

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -22,12 +22,12 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.go-version }}
-    - name: Checkout code
-      uses: actions/checkout@v3
     - name: Compile
       run: make build
     - name: golangci-lint


### PR DESCRIPTION
## Description

Checkout code before setting up go in test Action.
This allows caching to work while using setup-go and cleans up the warning from the GitHub Action.

## Type of change

* Bug fix (non-breaking change which fixes an issue)