### PR TITLE
feat: add opt-in promotion of Prometheus labels to BigQuery columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,11 +127,60 @@ You can configure this storage adapter either through command line options or en
 | `--googleAPItableID` | `PROMBQ_TABLE` | Yes | | Table name as shown in GCP |
 | `--googleAPIjsonkeypath` | `PROMBQ_GCP_JSON` | Yes\* | | Path to json keyfile for GCP service account. At least one of `--googleAPIjsonkeypath` or `--googleProjectID` must be specified. |
 | `--googleProjectID` | `PROMBQ_GCP_PROJECT_ID` | Yes\* | | The GCP `project_id` to use, overwriting the value from the keyfile if both are used. At least one of `--googleAPIjsonkeypath` or `--googleProjectID` must be specified. |
+| `--promoted-labels` | `PROMBQ_PROMOTED_LABELS` | No | | Comma-separated `column:label[\|modifier]` pairs promoting Prometheus labels into dedicated BigQuery columns. See [Promoting labels to columns](#promoting-labels-to-columns) |
 | `--send-timeout` | `PROMBQ_TIMEOUT` | No | `30s` | The timeout to use when sending samples to the remote storage |
 | `--web.listen-address` | `PROMBQ_LISTEN` | No | `:9201` | Address to listen on for web endpoints |
 | `--web.telemetry-path` | `PROMBQ_TELEMETRY` | No | `/metrics` | Address to listen on for web endpoints |
 | `--log.level` | `PROMBQ_LOG_LEVEL` | No | `info` | Only log messages with the given severity or above. One of: [debug, info, warn, error] |
 | `--log.format` | `PROMBQ_LOG_FORMAT` | No | `logfmt` | Output format of log messages. One of: [logfmt, json] |
+
+## Promoting Labels To Columns
+
+By default every label except `__name__` is stored only inside the `tags` JSON string. If you query one label constantly, you can also have it written to its own top-level column with `--promoted-labels` (or `PROMBQ_PROMOTED_LABELS`):
+
+```shell
+./bigquery_remote_storage_adapter \
+  --googleProjectID=my-gcp-project-id \
+  --googleAPIdatasetID=prometheus \
+  --googleAPItableID=metrics_stream \
+  --promoted-labels=hostname:instance
+```
+
+Each entry is `column:label`, optionally followed by `|`-separated modifiers. Multiple entries are comma separated, and one label may feed more than one column:
+
+```
+--promoted-labels=hostname:instance,cluster:cluster
+--promoted-labels=hostname:instance|strip-port
+```
+
+| Modifier | Effect |
+| --- | --- |
+| `strip-port` | Removes a trailing `:<port>` from the value, so `web-01.example.net:9100` is stored as `web-01.example.net`. Bracketed IPv6 literals keep their brackets; a bare IPv6 address is left untouched. |
+| `omit-empty` | When the label is absent from a series, omit the column so it is stored as `NULL`. Only valid for `NULLABLE` columns — see below. |
+
+This feature is off by default. With no `--promoted-labels`, rows contain exactly the same four fields they always have and no table change is needed.
+
+**The column must exist before you enable the flag.** Add it first — this is additive and does not affect existing rows or queries:
+
+```sql
+ALTER TABLE `your_gcp_project.prometheus.metrics_stream`
+  ADD COLUMN IF NOT EXISTS hostname STRING;
+```
+
+A promoted column is written on **every** row: the label's value when the series has it, an empty string when it does not. That is what makes the feature safe for a column declared `REQUIRED`, since `REQUIRED` forbids `NULL` but accepts an empty string. Use `omit-empty` only when the column is `NULLABLE` and you need to tell "the series had no such label" apart from "the label was empty".
+
+Promoted labels are **also kept in the `tags` JSON**. Existing dashboards and `JSON_EXTRACT(tags, ...)` queries keep working unchanged, and a write/read round-trip through the adapter stays lossless. When `strip-port` is used, the column holds the stripped value while `tags` keeps the original.
+
+At startup the adapter reads the destination table's schema once and warns if a promoted column is missing, is not a `STRING`, or is declared `REPEATED` — a promoted value is always a single string, so any of those means rows will be rejected. It exits with an error if a `REQUIRED` column is configured with `omit-empty`, since that combination can never be satisfied. If the service account cannot read table metadata the check is skipped and the adapter starts normally.
+
+### Troubleshooting
+
+Both of these appear in the write path when the table and the configuration disagree. Failed rows are counted in `storage_bigquery_failed_samples_total`.
+
+| Error | Meaning |
+| --- | --- |
+| `Missing required field: ....<column>` | The column exists and is `REQUIRED`, but the row carried no value for it — for example a stock build writing to a table that expects a promoted column. |
+| `no such field: <column>` | The column does not exist in the destination table. Run the `ALTER TABLE` above. |
 
 ## Configuring Prometheus
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ Each entry is `column:label`, optionally followed by `|`-separated modifiers. Mu
 
 This feature is off by default. With no `--promoted-labels`, rows contain exactly the same four fields they always have and no table change is needed.
 
+Column names are compared **case-insensitively**, the way BigQuery itself treats them: `Hostname` and `hostname` are the same column. Two entries differing only in case are rejected at startup, as is a core column name (`value`, `metricname`, `timestamp`, `tags`) in any case, and a column configured as `Hostname` is matched against a `hostname` field in the table rather than reported as missing.
+
 **The column must exist before you enable the flag.** Add it first — this is additive and does not affect existing rows or queries:
 
 ```sql

--- a/bigquerydb/client.go
+++ b/bigquerydb/client.go
@@ -47,10 +47,38 @@ type BigqueryClient struct {
 	batchWriteDuration prometheus.Histogram
 	sqlQueryCount      prometheus.Counter
 	sqlQueryDuration   prometheus.Histogram
+	promoted           []PromotedColumn
+}
+
+// CoreColumns are the column names every row always carries. Promoted columns
+// may never use these names, so a promoted key can never shadow a core field.
+var CoreColumns = []string{"value", "metricname", "timestamp", "tags"}
+
+// PromotedColumn maps a Prometheus label onto a dedicated top-level BigQuery
+// column. StripPort removes a trailing :port from the value. OmitEmpty drops
+// the key entirely when the label is absent, so the column is stored as NULL;
+// without it the column is written on every row (empty string when the label
+// is absent) so that a REQUIRED column can never be violated.
+type PromotedColumn struct {
+	Column    string
+	Label     string
+	StripPort bool
+	OmitEmpty bool
+}
+
+// ClientOption customizes a BigqueryClient. Options are variadic so that the
+// existing NewClient signature stays source-compatible for current callers.
+type ClientOption func(*BigqueryClient)
+
+// WithPromotedLabels configures labels to be promoted into their own columns.
+func WithPromotedLabels(cols []PromotedColumn) ClientOption {
+	return func(c *BigqueryClient) {
+		c.promoted = append([]PromotedColumn(nil), cols...)
+	}
 }
 
 // NewClient creates a new Client.
-func NewClient(logger *slog.Logger, googleAPIjsonkeypath, googleProjectID, googleAPIdatasetID, googleAPItableID string, remoteTimeout time.Duration) *BigqueryClient {
+func NewClient(logger *slog.Logger, googleAPIjsonkeypath, googleProjectID, googleAPIdatasetID, googleAPItableID string, remoteTimeout time.Duration, opts ...ClientOption) *BigqueryClient {
 	ctx := context.Background()
 	if logger == nil {
 		logger = promslog.NewNopLogger()
@@ -87,7 +115,7 @@ func NewClient(logger *slog.Logger, googleAPIjsonkeypath, googleProjectID, googl
 		os.Exit(1)
 	}
 
-	return &BigqueryClient{
+	bqc := &BigqueryClient{
 		logger:    logger,
 		client:    *c,
 		datasetID: googleAPIdatasetID,
@@ -125,6 +153,101 @@ func NewClient(logger *slog.Logger, googleAPIjsonkeypath, googleProjectID, googl
 			},
 		),
 	}
+
+	for _, opt := range opts {
+		opt(bqc)
+	}
+	bqc.preflightPromotedColumns()
+
+	return bqc
+}
+
+// preflightPromotedColumns checks the destination table once at startup, but
+// only when promotion is configured, so the default path issues no extra API
+// call. A missing or mistyped column is a warning: rows will be rejected, but
+// loudly, and a warning must not block a restart. A REQUIRED column combined
+// with OmitEmpty is fatal because that pairing is guaranteed to reject rows.
+// Unreadable metadata is not fatal either, since a write-scoped service
+// account may lack bigquery.tables.get.
+func (c *BigqueryClient) preflightPromotedColumns() {
+	if len(c.promoted) == 0 {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
+	defer cancel()
+
+	md, err := c.client.Dataset(c.datasetID).Table(c.tableID).Metadata(ctx)
+	if err != nil {
+		c.logger.Debug("could not read destination table schema, skipping promoted column preflight", slog.Any("error", err))
+		return
+	}
+
+	fatal := false
+	for _, issue := range checkPromotedColumns(md.Schema, c.promoted) {
+		if issue.fatal {
+			c.logger.Error(issue.reason, slog.Any("column", issue.column))
+			fatal = true
+			continue
+		}
+		c.logger.Warn(issue.reason, slog.Any("column", issue.column))
+	}
+	if fatal {
+		os.Exit(1)
+	}
+}
+
+// promotedSchemaIssue is one problem found when comparing the configured
+// promoted columns against the destination table schema.
+type promotedSchemaIssue struct {
+	column string
+	reason string
+	fatal  bool
+}
+
+// checkPromotedColumns compares the configured promoted columns against a table
+// schema. It is separated from the API call so it can be tested without a live
+// BigQuery table. Only an unsatisfiable configuration is fatal; everything else
+// is a warning, because rows rejected at write time surface loudly through
+// storage_bigquery_failed_samples_total and must not block a restart.
+func checkPromotedColumns(schema bigquery.Schema, promoted []PromotedColumn) []promotedSchemaIssue {
+	declared := make(map[string]*bigquery.FieldSchema, len(schema))
+	for _, f := range schema {
+		declared[f.Name] = f
+	}
+
+	var issues []promotedSchemaIssue
+	for _, p := range promoted {
+		f, ok := declared[p.Column]
+		if !ok {
+			issues = append(issues, promotedSchemaIssue{
+				column: p.Column,
+				reason: "promoted column does not exist in the destination table, rows will be rejected until it is added",
+			})
+			continue
+		}
+		if f.Repeated {
+			issues = append(issues, promotedSchemaIssue{
+				column: p.Column,
+				reason: "promoted column is REPEATED, but a promoted value is a single string, rows will be rejected",
+			})
+		}
+		if f.Type != bigquery.StringFieldType {
+			issues = append(issues, promotedSchemaIssue{
+				column: p.Column,
+				reason: fmt.Sprintf("promoted column has type %s, but a promoted value is a string, rows will be rejected", f.Type),
+			})
+		}
+		// Repeated fields are never Required, so this cannot double-report.
+		if f.Required && p.OmitEmpty {
+			issues = append(issues, promotedSchemaIssue{
+				column: p.Column,
+				reason: "promoted column is REQUIRED but configured with omit-empty, which can never satisfy it",
+				fatal:  true,
+			})
+		}
+	}
+	return issues
 }
 
 // Item represents a row item.
@@ -133,16 +256,81 @@ type Item struct {
 	metricname string  `bigquery:"metricname"`
 	timestamp  int64   `bigquery:"timestamp"`
 	tags       string  `bigquery:"tags"`
+	promoted   map[string]string
 }
 
 // Save implements the ValueSaver interface.
 func (i *Item) Save() (map[string]bigquery.Value, string, error) {
-	return map[string]bigquery.Value{
+	row := map[string]bigquery.Value{
 		"value":      i.value,
 		"metricname": i.metricname,
 		"timestamp":  i.timestamp,
 		"tags":       i.tags,
-	}, "", nil
+	}
+	// Promoted column names are validated at startup against CoreColumns, so
+	// none of these keys can overwrite one of the four above.
+	for column, value := range i.promoted {
+		row[column] = value
+	}
+	return row, "", nil
+}
+
+// promotedValues resolves the configured promoted columns for one time series.
+// It returns nil when promotion is disabled, so the default row shape is
+// untouched.
+func (c *BigqueryClient) promotedValues(m model.Metric) map[string]string {
+	if len(c.promoted) == 0 {
+		return nil
+	}
+	values := make(map[string]string, len(c.promoted))
+	for _, p := range c.promoted {
+		v, ok := m[model.LabelName(p.Label)]
+		if !ok {
+			if p.OmitEmpty {
+				continue
+			}
+			// The column is written on every row: a REQUIRED column rejects a
+			// missing key, but accepts an empty string.
+			values[p.Column] = ""
+			continue
+		}
+		value := string(v)
+		if p.StripPort {
+			value = stripPort(value)
+		}
+		values[p.Column] = value
+	}
+	return values
+}
+
+// stripPort removes a trailing :port from a host string. Bracketed IPv6
+// literals keep their brackets, and a bare IPv6 address is left alone since it
+// cannot be told apart from a host:port pair with certainty.
+func stripPort(s string) string {
+	if strings.HasPrefix(s, "[") {
+		if end := strings.LastIndex(s, "]"); end != -1 {
+			return s[:end+1]
+		}
+		return s
+	}
+	i := strings.LastIndex(s, ":")
+	if i == -1 {
+		return s
+	}
+	if strings.Contains(s[:i], ":") {
+		// More than one colon and no brackets: treat as a bare IPv6 address.
+		return s
+	}
+	port := s[i+1:]
+	if port == "" {
+		return s
+	}
+	for _, r := range port {
+		if r < '0' || r > '9' {
+			return s
+		}
+	}
+	return s[:i]
 }
 
 // tagsFromMetric extracts tags from a Prometheus MetricNameLabel.
@@ -175,6 +363,8 @@ func (c *BigqueryClient) Write(timeseries []*prompb.TimeSeries) error {
 		}
 
 		t := tagsFromMetric(metric)
+		// Resolved once per series rather than per sample.
+		promoted := c.promotedValues(metric)
 
 		for _, s := range samples {
 			v := float64(s.Value)
@@ -189,6 +379,7 @@ func (c *BigqueryClient) Write(timeseries []*prompb.TimeSeries) error {
 				metricname: string(metric[model.MetricNameLabel]),
 				timestamp:  model.Time(s.Timestamp).Unix(),
 				tags:       t,
+				promoted:   promoted,
 			})
 		}
 	}

--- a/bigquerydb/client.go
+++ b/bigquerydb/client.go
@@ -211,14 +211,17 @@ type promotedSchemaIssue struct {
 // is a warning, because rows rejected at write time surface loudly through
 // storage_bigquery_failed_samples_total and must not block a restart.
 func checkPromotedColumns(schema bigquery.Schema, promoted []PromotedColumn) []promotedSchemaIssue {
+	// BigQuery column names are case-insensitive, so "Hostname" configured
+	// against a "hostname" field is the same column. Fold both sides of the
+	// lookup, otherwise a mere case difference is reported as a missing column.
 	declared := make(map[string]*bigquery.FieldSchema, len(schema))
 	for _, f := range schema {
-		declared[f.Name] = f
+		declared[strings.ToLower(f.Name)] = f
 	}
 
 	var issues []promotedSchemaIssue
 	for _, p := range promoted {
-		f, ok := declared[p.Column]
+		f, ok := declared[strings.ToLower(p.Column)]
 		if !ok {
 			issues = append(issues, promotedSchemaIssue{
 				column: p.Column,

--- a/bigquerydb/client_test.go
+++ b/bigquerydb/client_test.go
@@ -254,3 +254,84 @@ func TestPromotedLabelColumns(t *testing.T) {
 	assert.Len(t, result.Results, 1)
 	assert.Equal(t, withInstance, result.Results[0].Timeseries)
 }
+
+// TestPromotedLabelColumnCaseMismatch pins the behaviour BigQuery actually has:
+// column names are case-insensitive, so a column configured as "Hostname"
+// against a table field named "hostname" is the same column. It must neither be
+// flagged as missing by the preflight nor rejected on write.
+func TestPromotedLabelColumnCaseMismatch(t *testing.T) {
+	ctx := context.Background()
+	nowUnix := time.Now().Unix() * 1000
+	promotedTableID := googleAPItableID + "_promoted_case"
+
+	client, err := bigquery.NewClient(ctx, googleProjectID)
+	if err != nil {
+		t.Fatal("failed to create bigquery client", err)
+	}
+	defer client.Close()
+
+	table := client.Dataset(googleAPIdatasetID).Table(promotedTableID)
+	err = table.Create(ctx, &bigquery.TableMetadata{
+		Schema: bigquery.Schema{
+			{Name: "metricname", Type: bigquery.StringFieldType},
+			{Name: "tags", Type: bigquery.StringFieldType},
+			{Name: "timestamp", Type: bigquery.TimestampFieldType},
+			{Name: "value", Type: bigquery.FloatFieldType},
+			// Declared lower case, configured below as "Hostname".
+			{Name: "hostname", Type: bigquery.StringFieldType, Required: true},
+		},
+		TimePartitioning: &bigquery.TimePartitioning{Field: "timestamp"},
+	})
+	if err != nil {
+		t.Fatal("failed to create promoted test table", err)
+	}
+	defer func() {
+		if err := table.Delete(ctx); err != nil {
+			t.Logf("failed to drop promoted test table %s: %v", promotedTableID, err)
+		}
+	}()
+
+	timeseries := []*prompb.TimeSeries{{
+		Labels: []*prompb.Label{
+			{Name: "__name__", Value: "promoted_case_mismatch"},
+			{Name: "instance", Value: "web-01.example.net"},
+		},
+		Samples: []prompb.Sample{{Timestamp: nowUnix, Value: 1}},
+	}}
+
+	// NewClient runs the preflight: a case-only difference must not warn, and
+	// must not be fatal.
+	bqclient := NewClient(logger, "", googleProjectID, googleAPIdatasetID, promotedTableID, bigQueryClientTimeout,
+		WithPromotedLabels([]PromotedColumn{{Column: "Hostname", Label: "instance"}}))
+
+	assert.Empty(t, checkPromotedColumns(bigquery.Schema{
+		{Name: "hostname", Type: bigquery.StringFieldType, Required: true},
+	}, []PromotedColumn{{Column: "Hostname", Label: "instance"}}),
+		"a case-only difference is the same column and must not be reported")
+
+	assert.NoError(t, bqclient.Write(timeseries), "a differently-cased promoted key must still be accepted")
+
+	query := client.Query(fmt.Sprintf(
+		"SELECT metricname, hostname FROM %s.%s", googleAPIdatasetID, promotedTableID))
+	iter, err := query.Read(ctx)
+	if err != nil {
+		t.Fatal("failed to query promoted test table", err)
+	}
+
+	stored := map[string]string{}
+	for {
+		row := map[string]bigquery.Value{}
+		err := iter.Next(&row)
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			t.Fatal("failed to read promoted test table", err)
+		}
+		hostname, _ := row["hostname"].(string)
+		metricname, _ := row["metricname"].(string)
+		stored[metricname] = hostname
+	}
+
+	assert.Equal(t, map[string]string{"promoted_case_mismatch": "web-01.example.net"}, stored)
+}

--- a/bigquerydb/client_test.go
+++ b/bigquerydb/client_test.go
@@ -16,14 +16,18 @@ limitations under the License.
 package bigquerydb
 
 import (
+	"context"
+	"fmt"
 	"log/slog"
 	"math"
 	"os"
 	"testing"
 	"time"
 
+	"cloud.google.com/go/bigquery"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/api/iterator"
 )
 
 var bigQueryClientTimeout = time.Second * 60
@@ -145,4 +149,108 @@ func TestLabelMatchers(t *testing.T) {
 			assert.Equal(t, timeseriesData[testCase.expectedResult], result.Results[0].Timeseries)
 		})
 	}
+}
+
+// TestPromotedLabelColumns exercises promotion against a real table whose
+// promoted column is REQUIRED, mirroring production. It provisions and drops
+// its own table so bq-schema.json, the Makefile and the CI workflow need no
+// changes. This is the direct regression test for a stock binary writing no
+// hostname key and BigQuery rejecting every row with "Missing required field".
+func TestPromotedLabelColumns(t *testing.T) {
+	ctx := context.Background()
+	nowUnix := time.Now().Unix() * 1000
+	promotedTableID := googleAPItableID + "_promoted"
+
+	client, err := bigquery.NewClient(ctx, googleProjectID)
+	if err != nil {
+		t.Fatal("failed to create bigquery client", err)
+	}
+	defer client.Close()
+
+	table := client.Dataset(googleAPIdatasetID).Table(promotedTableID)
+	err = table.Create(ctx, &bigquery.TableMetadata{
+		Schema: bigquery.Schema{
+			{Name: "metricname", Type: bigquery.StringFieldType},
+			{Name: "tags", Type: bigquery.StringFieldType},
+			{Name: "timestamp", Type: bigquery.TimestampFieldType},
+			{Name: "value", Type: bigquery.FloatFieldType},
+			// REQUIRED on purpose: an omitted key must be impossible.
+			{Name: "hostname", Type: bigquery.StringFieldType, Required: true},
+		},
+		TimePartitioning: &bigquery.TimePartitioning{Field: "timestamp"},
+	})
+	if err != nil {
+		t.Fatal("failed to create promoted test table", err)
+	}
+	defer func() {
+		if err := table.Delete(ctx); err != nil {
+			t.Logf("failed to drop promoted test table %s: %v", promotedTableID, err)
+		}
+	}()
+
+	withInstance := []*prompb.TimeSeries{{
+		Labels: []*prompb.Label{
+			{Name: "__name__", Value: "promoted_with_instance"},
+			{Name: "instance", Value: "web-01.example.net"},
+		},
+		Samples: []prompb.Sample{{Timestamp: nowUnix, Value: 1}},
+	}}
+	// No instance label at all: this is the row a REQUIRED column rejects
+	// unless the adapter writes an empty string for it.
+	withoutInstance := []*prompb.TimeSeries{{
+		Labels: []*prompb.Label{
+			{Name: "__name__", Value: "promoted_without_instance"},
+		},
+		Samples: []prompb.Sample{{Timestamp: nowUnix, Value: 2}},
+	}}
+
+	bqclient := NewClient(logger, "", googleProjectID, googleAPIdatasetID, promotedTableID, bigQueryClientTimeout,
+		WithPromotedLabels([]PromotedColumn{{Column: "hostname", Label: "instance"}}))
+
+	for _, timeseries := range [][]*prompb.TimeSeries{withInstance, withoutInstance} {
+		// A REQUIRED violation surfaces here as a PutMultiError, not silently.
+		assert.NoError(t, bqclient.Write(timeseries), "every row must be accepted by a REQUIRED promoted column")
+	}
+
+	query := client.Query(fmt.Sprintf(
+		"SELECT metricname, hostname FROM %s.%s ORDER BY metricname", googleAPIdatasetID, promotedTableID))
+	iter, err := query.Read(ctx)
+	if err != nil {
+		t.Fatal("failed to query promoted test table", err)
+	}
+
+	stored := map[string]string{}
+	for {
+		row := map[string]bigquery.Value{}
+		err := iter.Next(&row)
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			t.Fatal("failed to read promoted test table", err)
+		}
+		hostname, _ := row["hostname"].(string)
+		metricname, _ := row["metricname"].(string)
+		stored[metricname] = hostname
+	}
+
+	assert.Equal(t, map[string]string{
+		"promoted_with_instance":    "web-01.example.net",
+		"promoted_without_instance": "",
+	}, stored)
+
+	// The promoted label must still be in tags, so the read path round-trips.
+	result, err := bqclient.Read(&prompb.ReadRequest{
+		Queries: []*prompb.Query{{
+			StartTimestampMs: nowUnix,
+			EndTimestampMs:   nowUnix + 10000,
+			Matchers: []*prompb.LabelMatcher{
+				{Type: prompb.LabelMatcher_EQ, Name: "__name__", Value: "promoted_with_instance"},
+			},
+		}},
+	})
+
+	assert.NoError(t, err, "failed to process query")
+	assert.Len(t, result.Results, 1)
+	assert.Equal(t, withInstance, result.Results[0].Timeseries)
 }

--- a/bigquerydb/client_unit_test.go
+++ b/bigquerydb/client_unit_test.go
@@ -1,0 +1,291 @@
+//go:build unit
+
+/*
+Copyright 2020 Kohl's Department Stores, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+	http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bigquerydb
+
+import (
+	"encoding/json"
+	"testing"
+
+	"cloud.google.com/go/bigquery"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestPromotedDisabledKeepsDefaultRowShape is the regression guard for existing
+// users: with no promotion configured a row must contain exactly the four core
+// keys, so a fifth key can never be introduced by default.
+func TestPromotedDisabledKeepsDefaultRowShape(t *testing.T) {
+	item := &Item{value: 1.5, metricname: "up", timestamp: 1234, tags: `{"job":"node"}`}
+
+	row, insertID, err := item.Save()
+
+	assert.NoError(t, err)
+	assert.Empty(t, insertID)
+	assert.Equal(t, map[string]bigquery.Value{
+		"value":      1.5,
+		"metricname": "up",
+		"timestamp":  int64(1234),
+		"tags":       `{"job":"node"}`,
+	}, row)
+	assert.Len(t, row, len(CoreColumns))
+}
+
+func TestPromotedSaveAddsColumnsWithoutTouchingCoreFields(t *testing.T) {
+	base := &Item{value: 1.5, metricname: "up", timestamp: 1234, tags: `{"job":"node"}`}
+	baseRow, _, err := base.Save()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	item := &Item{
+		value: 1.5, metricname: "up", timestamp: 1234, tags: `{"job":"node"}`,
+		promoted: map[string]string{"hostname": "web-01.example.net"},
+	}
+	row, _, err := item.Save()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, "web-01.example.net", row["hostname"])
+	assert.Len(t, row, len(CoreColumns)+1)
+	for _, column := range CoreColumns {
+		assert.Equal(t, baseRow[column], row[column], "core column %q must be unchanged by promotion", column)
+	}
+}
+
+func TestPromotedValuesVerbatim(t *testing.T) {
+	c := &BigqueryClient{promoted: []PromotedColumn{{Column: "hostname", Label: "instance"}}}
+
+	values := c.promotedValues(model.Metric{
+		model.MetricNameLabel: "up",
+		"instance":            "au-syd-dc1-b1.cloud.openvpn.net",
+	})
+
+	assert.Equal(t, map[string]string{"hostname": "au-syd-dc1-b1.cloud.openvpn.net"}, values)
+}
+
+// A port is retained unless strip-port is configured.
+func TestPromotedValuesRetainsPortByDefault(t *testing.T) {
+	c := &BigqueryClient{promoted: []PromotedColumn{{Column: "hostname", Label: "instance"}}}
+
+	values := c.promotedValues(model.Metric{"instance": "localhost:9090"})
+
+	assert.Equal(t, map[string]string{"hostname": "localhost:9090"}, values)
+}
+
+// The REQUIRED-column guarantee: an absent label yields an empty string, never
+// a missing key, because REQUIRED forbids NULL but accepts "".
+func TestPromotedValuesAbsentLabelWritesEmptyString(t *testing.T) {
+	c := &BigqueryClient{promoted: []PromotedColumn{{Column: "hostname", Label: "instance"}}}
+
+	values := c.promotedValues(model.Metric{model.MetricNameLabel: "up"})
+
+	assert.Contains(t, values, "hostname")
+	assert.Equal(t, "", values["hostname"])
+}
+
+func TestPromotedValuesPreservesEmptyLabelValue(t *testing.T) {
+	c := &BigqueryClient{promoted: []PromotedColumn{{Column: "hostname", Label: "instance"}}}
+
+	values := c.promotedValues(model.Metric{"instance": ""})
+
+	assert.Contains(t, values, "hostname")
+	assert.Equal(t, "", values["hostname"])
+}
+
+func TestPromotedValuesOmitEmptyDropsKey(t *testing.T) {
+	c := &BigqueryClient{promoted: []PromotedColumn{{Column: "cluster", Label: "cluster", OmitEmpty: true}}}
+
+	assert.NotContains(t, c.promotedValues(model.Metric{model.MetricNameLabel: "up"}), "cluster")
+	assert.Equal(t, map[string]string{"cluster": "prod"}, c.promotedValues(model.Metric{"cluster": "prod"}))
+}
+
+func TestPromotedValuesDisabledReturnsNil(t *testing.T) {
+	c := &BigqueryClient{}
+
+	assert.Nil(t, c.promotedValues(model.Metric{"instance": "localhost:9090"}))
+}
+
+func TestPromotedOneLabelIntoTwoColumns(t *testing.T) {
+	c := &BigqueryClient{promoted: []PromotedColumn{
+		{Column: "hostname", Label: "instance"},
+		{Column: "node", Label: "instance", StripPort: true},
+	}}
+
+	values := c.promotedValues(model.Metric{"instance": "web-01.example.net:9100"})
+
+	assert.Equal(t, map[string]string{
+		"hostname": "web-01.example.net:9100",
+		"node":     "web-01.example.net",
+	}, values)
+}
+
+func TestPromotedStripPort(t *testing.T) {
+	testCases := map[string]struct {
+		in       string
+		expected string
+	}{
+		"host and port":          {in: "localhost:9090", expected: "localhost"},
+		"fqdn and port":          {in: "web-01.example.net:9100", expected: "web-01.example.net"},
+		"already port free":      {in: "au-syd-dc1-b1.cloud.openvpn.net", expected: "au-syd-dc1-b1.cloud.openvpn.net"},
+		"ipv4 and port":          {in: "10.0.0.5:9100", expected: "10.0.0.5"},
+		"bracketed ipv6 w/ port": {in: "[2001:db8::1]:9100", expected: "[2001:db8::1]"},
+		"bracketed ipv6 no port": {in: "[2001:db8::1]", expected: "[2001:db8::1]"},
+		"bare ipv6 left alone":   {in: "2001:db8::1", expected: "2001:db8::1"},
+		"non numeric suffix":     {in: "host:name", expected: "host:name"},
+		"trailing colon":         {in: "host:", expected: "host:"},
+		"empty":                  {in: "", expected: ""},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, stripPort(tc.in))
+		})
+	}
+}
+
+// Promotion must not remove the label from the tags JSON, so existing
+// JSON_EXTRACT queries and the read path keep working.
+func TestPromotedLabelIsRetainedInTags(t *testing.T) {
+	metric := model.Metric{
+		model.MetricNameLabel: "up",
+		"instance":            "localhost:9090",
+		"job":                 "node",
+	}
+	c := &BigqueryClient{promoted: []PromotedColumn{{Column: "hostname", Label: "instance", StripPort: true}}}
+
+	values := c.promotedValues(metric)
+	var tags map[string]string
+	if err := json.Unmarshal([]byte(tagsFromMetric(metric)), &tags); err != nil {
+		t.Fatal(err)
+	}
+
+	// The column is stripped, the tags JSON keeps the original value verbatim.
+	assert.Equal(t, "localhost", values["hostname"])
+	assert.Equal(t, "localhost:9090", tags["instance"])
+	assert.Equal(t, "node", tags["job"])
+	assert.NotContains(t, tags, model.MetricNameLabel)
+}
+
+func TestPromotedMixedBatchPerRowKeys(t *testing.T) {
+	c := &BigqueryClient{promoted: []PromotedColumn{{Column: "hostname", Label: "instance"}}}
+
+	withLabel := c.promotedValues(model.Metric{"instance": "web-01.example.net"})
+	withoutLabel := c.promotedValues(model.Metric{model.MetricNameLabel: "aggregated"})
+
+	assert.Equal(t, "web-01.example.net", withLabel["hostname"])
+	assert.Equal(t, "", withoutLabel["hostname"])
+	assert.Contains(t, withoutLabel, "hostname")
+}
+
+// The preflight logic is tested against a plain schema value, with no live
+// BigQuery table, so a mistyped destination column is covered without GCP.
+func TestPromotedSchemaPreflight(t *testing.T) {
+	mapping := []PromotedColumn{{Column: "hostname", Label: "instance"}}
+	omitEmptyMapping := []PromotedColumn{{Column: "hostname", Label: "instance", OmitEmpty: true}}
+
+	testCases := map[string]struct {
+		schema        bigquery.Schema
+		promoted      []PromotedColumn
+		expectIssues  int
+		expectFatal   bool
+		reasonKeyword string
+	}{
+		"correct STRING NULLABLE column": {
+			schema:   bigquery.Schema{{Name: "hostname", Type: bigquery.StringFieldType}},
+			promoted: mapping,
+		},
+		"correct STRING REQUIRED column, always written": {
+			schema:   bigquery.Schema{{Name: "hostname", Type: bigquery.StringFieldType, Required: true}},
+			promoted: mapping,
+		},
+		"column missing entirely": {
+			schema:        bigquery.Schema{{Name: "tags", Type: bigquery.StringFieldType}},
+			promoted:      mapping,
+			expectIssues:  1,
+			reasonKeyword: "does not exist",
+		},
+		"wrong type INTEGER": {
+			schema:        bigquery.Schema{{Name: "hostname", Type: bigquery.IntegerFieldType}},
+			promoted:      mapping,
+			expectIssues:  1,
+			reasonKeyword: "type INTEGER",
+		},
+		"wrong type TIMESTAMP": {
+			schema:        bigquery.Schema{{Name: "hostname", Type: bigquery.TimestampFieldType}},
+			promoted:      mapping,
+			expectIssues:  1,
+			reasonKeyword: "type TIMESTAMP",
+		},
+		"wrong type RECORD": {
+			schema:        bigquery.Schema{{Name: "hostname", Type: bigquery.RecordFieldType}},
+			promoted:      mapping,
+			expectIssues:  1,
+			reasonKeyword: "type RECORD",
+		},
+		"REPEATED string column": {
+			schema:        bigquery.Schema{{Name: "hostname", Type: bigquery.StringFieldType, Repeated: true}},
+			promoted:      mapping,
+			expectIssues:  1,
+			reasonKeyword: "REPEATED",
+		},
+		"REPEATED and wrong type reports both": {
+			schema:       bigquery.Schema{{Name: "hostname", Type: bigquery.IntegerFieldType, Repeated: true}},
+			promoted:     mapping,
+			expectIssues: 2,
+		},
+		"REQUIRED with omit-empty is fatal": {
+			schema:        bigquery.Schema{{Name: "hostname", Type: bigquery.StringFieldType, Required: true}},
+			promoted:      omitEmptyMapping,
+			expectIssues:  1,
+			expectFatal:   true,
+			reasonKeyword: "omit-empty",
+		},
+		"NULLABLE with omit-empty is fine": {
+			schema:   bigquery.Schema{{Name: "hostname", Type: bigquery.StringFieldType}},
+			promoted: omitEmptyMapping,
+		},
+		"no promotion configured yields nothing": {
+			schema:   bigquery.Schema{{Name: "hostname", Type: bigquery.IntegerFieldType}},
+			promoted: nil,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			issues := checkPromotedColumns(tc.schema, tc.promoted)
+
+			assert.Len(t, issues, tc.expectIssues)
+
+			fatal := false
+			for _, issue := range issues {
+				if issue.fatal {
+					fatal = true
+				}
+				assert.Equal(t, "hostname", issue.column)
+			}
+			assert.Equal(t, tc.expectFatal, fatal)
+
+			if tc.reasonKeyword != "" && len(issues) > 0 {
+				joined := ""
+				for _, issue := range issues {
+					joined += issue.reason + "\n"
+				}
+				assert.Contains(t, joined, tc.reasonKeyword)
+			}
+		})
+	}
+}

--- a/bigquerydb/client_unit_test.go
+++ b/bigquerydb/client_unit_test.go
@@ -289,3 +289,46 @@ func TestPromotedSchemaPreflight(t *testing.T) {
 		})
 	}
 }
+
+// BigQuery column names are case-insensitive, so a column configured as
+// "Hostname" against a schema field "hostname" is the same column and must not
+// be reported as missing. The mismatched case still has to be checked for type
+// and mode, since that is the column the rows will actually land in.
+func TestCheckPromotedColumnsIsCaseInsensitive(t *testing.T) {
+	testCases := map[string]struct {
+		schema       bigquery.Schema
+		promoted     []PromotedColumn
+		expectIssues int
+	}{
+		"configured upper, declared lower": {
+			schema:   bigquery.Schema{{Name: "hostname", Type: bigquery.StringFieldType}},
+			promoted: []PromotedColumn{{Column: "Hostname", Label: "instance"}},
+		},
+		"configured lower, declared upper": {
+			schema:   bigquery.Schema{{Name: "Hostname", Type: bigquery.StringFieldType}},
+			promoted: []PromotedColumn{{Column: "hostname", Label: "instance"}},
+		},
+		"case mismatch still validates the type": {
+			schema:       bigquery.Schema{{Name: "hostname", Type: bigquery.IntegerFieldType}},
+			promoted:     []PromotedColumn{{Column: "Hostname", Label: "instance"}},
+			expectIssues: 1,
+		},
+		"genuinely missing column is still reported": {
+			schema:       bigquery.Schema{{Name: "tags", Type: bigquery.StringFieldType}},
+			promoted:     []PromotedColumn{{Column: "Hostname", Label: "instance"}},
+			expectIssues: 1,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			issues := checkPromotedColumns(tc.schema, tc.promoted)
+
+			assert.Len(t, issues, tc.expectIssues)
+			for _, issue := range issues {
+				// The issue names the column as the operator configured it.
+				assert.Equal(t, tc.promoted[0].Column, issue.column)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -72,9 +72,14 @@ func parsePromotedLabels(raw string) ([]bigquerydb.PromotedColumn, error) {
 		return nil, nil
 	}
 
+	// BigQuery treats column names case-insensitively: a table cannot hold both
+	// "hostname" and "Hostname", and an insert keyed on the wrong case resolves
+	// to the same column. Go maps are case-sensitive, so every uniqueness and
+	// reservation check below folds the name first; the configured spelling is
+	// still what gets written.
 	reserved := make(map[string]bool, len(bigquerydb.CoreColumns))
 	for _, c := range bigquerydb.CoreColumns {
-		reserved[c] = true
+		reserved[strings.ToLower(c)] = true
 	}
 
 	var columns []bigquerydb.PromotedColumn
@@ -104,13 +109,14 @@ func parsePromotedLabels(raw string) ([]bigquerydb.PromotedColumn, error) {
 		if !promotedLabelRegexp.MatchString(label) {
 			return nil, errors.Errorf("promoted label %q: %q is not a valid Prometheus label name", entry, label)
 		}
-		if reserved[column] {
+		folded := strings.ToLower(column)
+		if reserved[folded] {
 			return nil, errors.Errorf("promoted label %q: %q is a reserved column name", entry, column)
 		}
-		if seen[column] {
+		if seen[folded] {
 			return nil, errors.Errorf("promoted label %q: column %q is mapped more than once", entry, column)
 		}
-		seen[column] = true
+		seen[folded] = true
 
 		promoted := bigquerydb.PromotedColumn{Column: column, Label: label}
 		for _, modifier := range parts[1:] {

--- a/main.go
+++ b/main.go
@@ -24,6 +24,8 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"regexp"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -48,8 +50,83 @@ type config struct {
 	remoteTimeout        time.Duration
 	listenAddr           string
 	telemetryPath        string
+	promotedLabels       string
+	promotedColumns      []bigquerydb.PromotedColumn
 	promslogConfig       promslog.Config
 	printVersion         bool
+}
+
+// Column names must be valid BigQuery identifiers, label names must be valid
+// Prometheus label names.
+var (
+	promotedColumnRegexp = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]{0,299}$`)
+	promotedLabelRegexp  = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+)
+
+// parsePromotedLabels parses the --promoted-labels value: a comma separated
+// list of column:label[|modifier] entries. Parsing happens once at startup so
+// that a bad mapping fails fast, rather than producing one rejected row and
+// one log line per sample for as long as the process runs.
+func parsePromotedLabels(raw string) ([]bigquerydb.PromotedColumn, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, nil
+	}
+
+	reserved := make(map[string]bool, len(bigquerydb.CoreColumns))
+	for _, c := range bigquerydb.CoreColumns {
+		reserved[c] = true
+	}
+
+	var columns []bigquerydb.PromotedColumn
+	seen := make(map[string]bool)
+
+	for _, entry := range strings.Split(raw, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+
+		parts := strings.Split(entry, "|")
+		pair := strings.TrimSpace(parts[0])
+
+		kv := strings.Split(pair, ":")
+		if len(kv) != 2 {
+			return nil, errors.Errorf("promoted label %q must be of the form column:label", entry)
+		}
+		column := strings.TrimSpace(kv[0])
+		label := strings.TrimSpace(kv[1])
+		if column == "" || label == "" {
+			return nil, errors.Errorf("promoted label %q must have a non-empty column and label", entry)
+		}
+		if !promotedColumnRegexp.MatchString(column) {
+			return nil, errors.Errorf("promoted label %q: %q is not a valid BigQuery column name", entry, column)
+		}
+		if !promotedLabelRegexp.MatchString(label) {
+			return nil, errors.Errorf("promoted label %q: %q is not a valid Prometheus label name", entry, label)
+		}
+		if reserved[column] {
+			return nil, errors.Errorf("promoted label %q: %q is a reserved column name", entry, column)
+		}
+		if seen[column] {
+			return nil, errors.Errorf("promoted label %q: column %q is mapped more than once", entry, column)
+		}
+		seen[column] = true
+
+		promoted := bigquerydb.PromotedColumn{Column: column, Label: label}
+		for _, modifier := range parts[1:] {
+			switch strings.TrimSpace(modifier) {
+			case "strip-port":
+				promoted.StripPort = true
+			case "omit-empty":
+				promoted.OmitEmpty = true
+			default:
+				return nil, errors.Errorf("promoted label %q: unknown modifier %q", entry, strings.TrimSpace(modifier))
+			}
+		}
+		columns = append(columns, promoted)
+	}
+
+	return columns, nil
 }
 
 var (
@@ -138,6 +215,7 @@ func main() {
 		slog.Any("googleAPItableID", cfg.googleAPItableID),
 		slog.Any("telemetryPath", cfg.telemetryPath),
 		slog.Any("listenAddr", cfg.listenAddr),
+		slog.Any("promotedLabels", cfg.promotedLabels),
 		slog.Any("remoteTimeout", cfg.remoteTimeout))
 
 	writers, readers := buildClients(*logger, cfg)
@@ -169,7 +247,11 @@ func parseFlags() *config {
 		Envar("PROMBQ_LISTEN").Default(":9201").StringVar(&cfg.listenAddr)
 	a.Flag("web.telemetry-path", "Address to listen on for web endpoints.").
 		Envar("PROMBQ_TELEMETRY").Default("/metrics").StringVar(&cfg.telemetryPath)
-	cfg.promslogConfig.Level = &promslog.Level{}
+	a.Flag("promoted-labels", "Comma-separated column:label[|modifier] pairs promoting Prometheus labels into dedicated BigQuery columns (e.g. hostname:instance). Modifiers: strip-port, omit-empty. The columns must already exist in the destination table.").
+		Envar("PROMBQ_PROMOTED_LABELS").Default("").StringVar(&cfg.promotedLabels)
+	// Must use the constructor: &promslog.Level{} leaves the embedded
+	// slog.LevelVar nil, and kingpin's default handling dereferences it.
+	cfg.promslogConfig.Level = promslog.NewLevel()
 	a.Flag("log.level", "Only log messages with the given severity or above. One of: [debug, info, warn, error]").
 		Envar("PROMBQ_LOG_LEVEL").Default("info").SetValue(cfg.promslogConfig.Level)
 	cfg.promslogConfig.Format = &promslog.Format{}
@@ -184,6 +266,10 @@ func parseFlags() *config {
 	}
 
 	handle(err, a)
+
+	cfg.promotedColumns, err = parsePromotedLabels(cfg.promotedLabels)
+	handle(err, a)
+
 	if cfg.googleAPIjsonkeypath == "" {
 		googleProjectIDFlagCause.Required().StringVar(&cfg.googleProjectID)
 		_, err = a.Parse(os.Args[1:])
@@ -221,7 +307,8 @@ func buildClients(logger slog.Logger, cfg *config) ([]writer, []reader) {
 		cfg.googleProjectID,
 		cfg.googleAPIdatasetID,
 		cfg.googleAPItableID,
-		cfg.remoteTimeout)
+		cfg.remoteTimeout,
+		bigquerydb.WithPromotedLabels(cfg.promotedColumns))
 	prometheus.MustRegister(c)
 	writers = append(writers, c)
 	readers = append(readers, c)

--- a/main_unit_test.go
+++ b/main_unit_test.go
@@ -1,0 +1,136 @@
+//go:build unit
+
+/*
+Copyright 2020 Kohl's Department Stores, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+	http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"github.com/KohlsTechnology/prometheus_bigquery_remote_storage_adapter/bigquerydb"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParsePromotedLabelsValid(t *testing.T) {
+	testCases := map[string]struct {
+		raw      string
+		expected []bigquerydb.PromotedColumn
+	}{
+		"empty": {
+			raw: "", expected: nil,
+		},
+		"whitespace only": {
+			raw: "   ", expected: nil,
+		},
+		"single pair": {
+			raw:      "hostname:instance",
+			expected: []bigquerydb.PromotedColumn{{Column: "hostname", Label: "instance"}},
+		},
+		"multiple pairs": {
+			raw: "hostname:instance,cluster:cluster",
+			expected: []bigquerydb.PromotedColumn{
+				{Column: "hostname", Label: "instance"},
+				{Column: "cluster", Label: "cluster"},
+			},
+		},
+		"surrounding whitespace tolerated": {
+			raw: "hostname:instance, cluster:cluster ",
+			expected: []bigquerydb.PromotedColumn{
+				{Column: "hostname", Label: "instance"},
+				{Column: "cluster", Label: "cluster"},
+			},
+		},
+		"strip-port modifier": {
+			raw:      "hostname:instance|strip-port",
+			expected: []bigquerydb.PromotedColumn{{Column: "hostname", Label: "instance", StripPort: true}},
+		},
+		"omit-empty modifier": {
+			raw:      "cluster:cluster|omit-empty",
+			expected: []bigquerydb.PromotedColumn{{Column: "cluster", Label: "cluster", OmitEmpty: true}},
+		},
+		"both modifiers": {
+			raw:      "hostname:instance|strip-port|omit-empty",
+			expected: []bigquerydb.PromotedColumn{{Column: "hostname", Label: "instance", StripPort: true, OmitEmpty: true}},
+		},
+		"one label into two columns is allowed": {
+			raw: "hostname:instance,node:instance",
+			expected: []bigquerydb.PromotedColumn{
+				{Column: "hostname", Label: "instance"},
+				{Column: "node", Label: "instance"},
+			},
+		},
+		"underscore identifiers": {
+			raw:      "host_name:some_label",
+			expected: []bigquerydb.PromotedColumn{{Column: "host_name", Label: "some_label"}},
+		},
+		"empty entries skipped": {
+			raw:      "hostname:instance,,",
+			expected: []bigquerydb.PromotedColumn{{Column: "hostname", Label: "instance"}},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got, err := parsePromotedLabels(tc.raw)
+
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestParsePromotedLabelsInvalid(t *testing.T) {
+	testCases := map[string]struct {
+		raw         string
+		errContains string
+	}{
+		"missing colon":            {raw: "hostname", errContains: "column:label"},
+		"too many colons":          {raw: "hostname:instance:extra", errContains: "column:label"},
+		"empty label":              {raw: "hostname:", errContains: "non-empty"},
+		"empty column":             {raw: ":instance", errContains: "non-empty"},
+		"invalid column dash":      {raw: "host-name:instance", errContains: "valid BigQuery column name"},
+		"invalid column leading 9": {raw: "9host:instance", errContains: "valid BigQuery column name"},
+		"invalid label space":      {raw: "hostname:my label", errContains: "valid Prometheus label name"},
+		"invalid label dash":       {raw: "hostname:my-label", errContains: "valid Prometheus label name"},
+		"unknown modifier":         {raw: "hostname:instance|lowercase", errContains: `unknown modifier "lowercase"`},
+		"duplicate column":         {raw: "hostname:instance,hostname:node", errContains: "mapped more than once"},
+		"reserved value":           {raw: "value:instance", errContains: "reserved column name"},
+		"reserved metricname":      {raw: "metricname:instance", errContains: "reserved column name"},
+		"reserved timestamp":       {raw: "timestamp:instance", errContains: "reserved column name"},
+		"reserved tags":            {raw: "tags:instance", errContains: "reserved column name"},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got, err := parsePromotedLabels(tc.raw)
+
+			assert.Nil(t, got)
+			if assert.Error(t, err) {
+				assert.Contains(t, err.Error(), tc.errContains)
+			}
+		})
+	}
+}
+
+// Every reserved name must be exactly the set of columns a row always carries,
+// which is what makes it impossible for a promoted key to shadow a core field.
+func TestParsePromotedLabelsRejectsEveryCoreColumn(t *testing.T) {
+	for _, column := range bigquerydb.CoreColumns {
+		t.Run(column, func(t *testing.T) {
+			_, err := parsePromotedLabels(column + ":instance")
+
+			assert.Error(t, err)
+		})
+	}
+}

--- a/main_unit_test.go
+++ b/main_unit_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package main
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/KohlsTechnology/prometheus_bigquery_remote_storage_adapter/bigquerydb"
@@ -109,6 +110,20 @@ func TestParsePromotedLabelsInvalid(t *testing.T) {
 		"reserved metricname":      {raw: "metricname:instance", errContains: "reserved column name"},
 		"reserved timestamp":       {raw: "timestamp:instance", errContains: "reserved column name"},
 		"reserved tags":            {raw: "tags:instance", errContains: "reserved column name"},
+		// BigQuery would reject the table itself for these, so catching them at
+		// startup is the difference between a clear error and a per-row failure.
+		"duplicate column differing only in case": {
+			raw:         "hostname:instance,Hostname:node",
+			errContains: "mapped more than once",
+		},
+		"reserved column differing only in case": {
+			raw:         "Value:instance",
+			errContains: "reserved column name",
+		},
+		"reserved column upper case": {
+			raw:         "METRICNAME:instance",
+			errContains: "reserved column name",
+		},
 	}
 
 	for name, tc := range testCases {
@@ -131,6 +146,10 @@ func TestParsePromotedLabelsRejectsEveryCoreColumn(t *testing.T) {
 			_, err := parsePromotedLabels(column + ":instance")
 
 			assert.Error(t, err)
+
+			_, err = parsePromotedLabels(strings.ToUpper(column) + ":instance")
+
+			assert.Error(t, err, "core column must stay reserved regardless of case")
 		})
 	}
 }


### PR DESCRIPTION
## Description
Add --promoted-labels (PROMBQ_PROMOTED_LABELS), a comma-separated list of column:label[|modifier] entries mapping Prometheus labels onto dedicated top-level BigQuery columns, e.g. hostname:instance.

The flag is empty by default. When unset, rows contain exactly the same four keys as before and no extra API call is made, so existing deployments need no table migration and no config change.

When set, a promoted column is written on every row: the label's value when present, an empty string when absent. That keeps a column declared REQUIRED satisfiable, since REQUIRED forbids NULL but accepts an empty string. The omit-empty modifier opts into dropping the key so a NULLABLE column stores NULL instead. The strip-port modifier removes a trailing :port, and is IPv6-bracket aware.

Promoted labels are also retained in the tags JSON, so the read path, existing dashboards and existing JSON_EXTRACT queries are unaffected and a write/read round-trip stays lossless.

The mapping is parsed and validated once at startup: malformed entries, invalid identifiers, unknown modifiers, duplicate columns and the reserved names value/metricname/timestamp/tags all exit non-zero. When promotion is enabled the destination table schema is read once and a missing, non-STRING or REPEATED column is warned about; a REQUIRED column configured with omit-empty is fatal.

NewClient takes the mapping through a variadic ClientOption, so its existing signature and all current call sites are unchanged.
